### PR TITLE
Fix usage for windows

### DIFF
--- a/Client.js
+++ b/Client.js
@@ -1,4 +1,4 @@
-const { resolve } = require('path')
+const { resolve } = require('path').posix
 const { URL } = require('url')
 const fetch = require('nodeify-fetch')
 const parseArchive = require('./lib/archive/parse')


### PR DESCRIPTION
Executing path.resolve on windows is causing that not is adding the drive, to prevent this from happening make sure to use path.posix

Using the call:
```
const client = new froniusClient('http://wechselrichter');
  const archiveData = await client.powerFlow({
    // start: new Date('2021-10-16T00:00:00Z'),
    // end: new Date('2021-10-17T00:00:00Z'),
    format: 'raw'
  });
```
and execute this on windows will cause accessing the 
URL `http://wechselrichter/C:/solar_api/v1/GetPowerFlowRealtimeData.fcgi`

Another possibilty would be to use:
https://nodejs.org/api/url.html#url_url_resolve_from_to

